### PR TITLE
Use HTTPonly cookies instead of localstorage

### DIFF
--- a/src/app/api/rate/route.js
+++ b/src/app/api/rate/route.js
@@ -1,9 +1,12 @@
 import { PrismaClient } from '@prisma/client';
+import { cookies } from "next/headers";
 
 const prisma = new PrismaClient();
 
 export async function POST(req) { // Post Request to Database
-  const { resourceId, userId, value } = await req.json(); // Extracting the resourceId, userId and value from the request body
+  const { resourceId, value } = await req.json(); // Extracting the resourceId, userId and value from the request body
+  const cookieStore = await cookies();
+  const userId = cookieStore.get("userid")?.value;
 
   if (!resourceId || !userId || value == null) {
     return new Response(JSON.stringify({ error: "Invalid input" }), { status: 400 });

--- a/src/app/api/ratings/route.js
+++ b/src/app/api/ratings/route.js
@@ -1,25 +1,32 @@
 import { PrismaClient } from '@prisma/client';
+import { cookies } from "next/headers";
 const prisma = new PrismaClient();
 
 export async function POST(req) {
-  const { resourceId, userId } = await req.json();
+    const { resourceId } = await req.json();
+    const cookieStore = await cookies();
+    const userId = cookieStore.get("userid")?.value;
 
-  const existing = await prisma.rating.findFirst({
-    where: { resourceId, userId },
-  });
+    const existing = await prisma.rating.findFirst({
+        where: { resourceId, userId },
+    });
 
-  if (existing) {
-    return new Response(JSON.stringify({ message: "Already voted" }), { status: 400 });
-  }
+    if (existing) {
+        return new Response(JSON.stringify({ message: "Already voted" }), {
+            status: 400,
+        });
+    }
 
-  await prisma.rating.create({
-    data: { resourceId, userId },
-  });
+    await prisma.rating.create({
+        data: { resourceId, userId },
+    });
 
-  await prisma.resource.update({
-    where: { id: resourceId },
-    data: { upvotes: { increment: 1 } },
-  });
+    await prisma.resource.update({
+        where: { id: resourceId },
+        data: { upvotes: { increment: 1 } },
+    });
 
-  return new Response(JSON.stringify({ message: "Vote added" }), { status: 200 });
+    return new Response(JSON.stringify({ message: "Vote added" }), {
+        status: 200,
+    });
 }

--- a/src/app/components/subject_cards/subject_card.js
+++ b/src/app/components/subject_cards/subject_card.js
@@ -21,14 +21,15 @@ const SubjectCards = ({ query = "", limit = null }) => {
     const [allResources, setAllResources] = useState([]); // Store all resources
     const [loading, setLoading] = useState(false);
 
-    useEffect(() => {
+    /*     useEffect(() => {
         let storedId = localStorage.getItem("userId");
         if (!storedId) {
             storedId = uuidv4(); // generate new ID if
             localStorage.setItem("userId", storedId);
         }
         setUserId(storedId);
-    }, []);
+    }, []); */
+    // Removed this, as we now do it in middleware.
 
     useEffect(() => {
         const fetchResources = async () => {
@@ -77,12 +78,10 @@ const SubjectCards = ({ query = "", limit = null }) => {
 
     // Ratings Logic
     async function rateResource(resourceId, value) {
-        const userId = localStorage.getItem("userId");
-
         const response = await fetch("/api/rate", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ resourceId, userId, value }),
+            body: JSON.stringify({ resourceId, value }),
         }); // Sending the rating to the server
 
         const result = await response.json();

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { v4 as uuidv4 } from "uuid";
+
+export function middleware(request) {
+    // Get the existing userid cookie
+    const userid = request.cookies.get("userid");
+
+    // If the userid cookie doesn't exist, create a new one
+    if (!userid) {
+        // Generate a new UUID
+        const newUserId = uuidv4();
+
+        // Clone the response
+        const response = NextResponse.next();
+
+        // Set the cookie with HTTP-only flag
+        response.cookies.set({
+            name: "userid",
+            value: newUserId,
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production", // Only use HTTPS in production
+            sameSite: "lax",
+            path: "/",
+        });
+
+        return response;
+    }
+
+    return NextResponse.next();
+}
+
+// Configure which paths this middleware will run on
+export const config = {
+    matcher: [
+        /*
+         * Match all request paths except:
+         * - _next/static (static files)
+         * - _next/image (image optimization files)
+         * - favicon.ico (favicon file)
+         * - public folder
+         */
+        "/((?!_next/static|_next/image|favicon.ico|public/).*)",
+    ],
+};


### PR DESCRIPTION
Updates the userId functionality to use HTTPOnly cookies instead of localStorage for storing userId.
This prevents users from being able to change their userId and create many ratings.