### PR TITLE
Fix: Move resource fetching to inside suspense boundary

### DIFF
--- a/src/app/components/subject_cards/subject_card.js
+++ b/src/app/components/subject_cards/subject_card.js
@@ -138,15 +138,44 @@ const SubjectCards = ({ query = "", limit = null }) => {
 
 export default SubjectCards;
 
-export function SubjectCard({ resource, index, rateResource, className = "" }) {
+export function SubjectCard({
+    resource,
+    index,
+    rateResource,
+    className = "",
+    setSubjectTag,
+    setExamBoardTag,
+}) {
     return (
         <div className={`${className !== "" ? className : "card"}`}>
             <p className="resourceType">{resource.type}</p>
             <h3 className="resourceTitle">{resource.title}</h3>
             <div className="tags">
                 <p className="tag studyLevel">{resource.level}</p>
-                <p className="tag subject">{resource.subject}</p>
-                <p className="tag examBoard">{resource.examBoard}</p>
+                <p
+                    className={`tag subject ${
+                        setSubjectTag ? "cursor-pointer" : ""
+                    }`}
+                    onClick={() => {
+                        if (setSubjectTag) {
+                            setSubjectTag(resource.subject);
+                        }
+                    }}
+                >
+                    {resource.subject}
+                </p>
+                <p
+                    className={`tag examBoard ${
+                        setExamBoardTag ? "cursor-pointer" : ""
+                    }`}
+                    onClick={() => {
+                        if (setExamBoardTag) {
+                            setExamBoardTag(resource.examBoard);
+                        }
+                    }}
+                >
+                    {resource.examBoard}
+                </p>
             </div>
             <p className="resourceDescription">{resource.description}</p>
             <div className="linkAuthorContainer">

--- a/src/app/subjects/page.js
+++ b/src/app/subjects/page.js
@@ -24,16 +24,6 @@ export default async function Subjects({ searchParams }) {
 
     console.log(query);
 
-    // Fetch resources on the server
-    const resources =
-        (await fetchResources({
-            query,
-            examBoard,
-            subject,
-            type: resourceType,
-        })) ?? [];
-    const availableTags = (await fetchTags()) ?? [];
-
     return (
         <div className="min-h-screen flex flex-col">
             <Navbar />
@@ -60,24 +50,28 @@ export default async function Subjects({ searchParams }) {
                         <div className="h-12 animate-pulse bg-gray-200 rounded-md"></div>
                     }
                 >
-                    <Tags availableTags={availableTags} />
+                    <ServerTagsSuspense />
                 </Suspense>
 
                 <div className="w-full pb-8 md:pb-12">
-                    {/* Display resources with suspense for loading state */}
                     <Suspense
                         fallback={
                             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                                 {[...Array(6)].map((_, i) => (
                                     <div
                                         key={i}
-                                        className="h-64 animate-pulse bg-gray-200 rounded-lg"
+                                        className="h-64 animate-pulse bg-white rounded-lg"
                                     ></div>
                                 ))}
                             </div>
                         }
                     >
-                        <ResourceCards resources={resources} />
+                        <ServerResourcesSuspense
+                            query={query}
+                            examBoard={examBoard}
+                            subject={subject}
+                            resourceType={resourceType}
+                        />
                     </Suspense>
                 </div>
             </div>
@@ -85,6 +79,32 @@ export default async function Subjects({ searchParams }) {
         </div>
     );
 }
+
+async function ServerResourcesSuspense({
+    query,
+    examBoard,
+    subject,
+    resourceType,
+}) {
+    const resources =
+        (await fetchResources({
+            query,
+            examBoard,
+            subject,
+            type: resourceType,
+        })) ?? [];
+
+    return <ResourceCards resources={resources} />;
+}
+
+async function ServerTagsSuspense() {
+    const availableTags = (await fetchTags()) ?? [];
+
+    return <Tags availableTags={availableTags} />;
+}
+
+
+
 
 // Server-side function to fetch resources
 async function fetchResources({

--- a/src/app/subjects/resource-cards.jsx
+++ b/src/app/subjects/resource-cards.jsx
@@ -90,6 +90,8 @@ export default function ResourceCards({ resources }) {
                         key={index}
                         resource={resource}
                         rateResource={rateResource}
+                        setSubjectTag={setSubjectTag}
+                        setExamBoardTag={setExamBoardTag}
                         className="font-sans bg-white rounded-[10px] border border-black p-4 col-span-1 mb-5 min-h-[450px]"
                     />
                 ))


### PR DESCRIPTION
Just a small fix that moves where data is fetched within the components to actually work with the suspense boundary on the subjects page.
Reduces initial page load time, showing a "Loading" state whilst content loads.